### PR TITLE
Fix vite version on package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^3.0.24",
     "tslib": "^2.4.0",
     "typescript": "^4.7.3",
-    "vite": "^2.9.9"
+    "vite": "^3.0.0"
   },
   "dependencies": {
     "@jamescoyle/svelte-icon": "^0.1.1",


### PR DESCRIPTION
Fix vite version from 2.9.9 to 3.0.0 following the Wails v2.0.0-beta.42 update.